### PR TITLE
Add manual permits protection for infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,10 +140,17 @@ workflows:
           filters:
             branches:
               only: master
+      - permit-staging-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-              - build-and-test
+              - permit-staging-release
           filters:
              branches:
                only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,10 +121,17 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
+      - permit-development-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
-            - build-and-test
+            - permit-development-release
           filters:
             branches:
               only: development


### PR DESCRIPTION
# What:
 - Add manual permits before infrastructure deployment steps.

# Why:
 - Prevent accidental deployment/destruction of resources.
