### PR TITLE
Rewire the pipeline to work with github flow strategy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,14 +117,10 @@ jobs:
           stage: 'production'
 
 workflows:
-  check-and-deploy-development:
+  deploy-development:
     jobs:
-      - check-code-formatting
-      - build-and-test
       - permit-development-release:
           type: approval
-          requires:
-            - build-and-test
           filters:
             branches:
               only: development
@@ -141,16 +137,10 @@ workflows:
           filters:
             branches:
               only: development
-  check-and-deploy-staging-and-production:
+  deploy-staging-and-production:
     jobs:
-      - build-and-test:
-          filters:
-            branches:
-              only: master
       - permit-staging-release:
           type: approval
-          requires:
-            - build-and-test
           filters:
             branches:
               only: master
@@ -183,7 +173,6 @@ workflows:
                only: master
       - deploy-to-production:
           requires:
-            - permit-production-release
             - assume-role-production
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           stage: 'production'
 
 workflows:
-  deploy-development:
+  deploy-staging-and-production:
     jobs:
       - permit-development-release:
           type: approval
@@ -110,8 +110,7 @@ workflows:
           filters:
             branches:
               only: development
-  deploy-staging-and-production:
-    jobs:
+#
       - permit-staging-release:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,27 +64,6 @@ commands:
             sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
-  check-code-formatting:
-    executor: docker-dotnet
-    steps:
-      - checkout
-      - run:
-          name: Install dotnet format
-          command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - run:
-          name: Run formatter check
-          command: ./dotnet-format-local/dotnet-format --check
-  build-and-test:
-    executor: docker-python
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: build
-          command: docker-compose build resident-vulnerabilities-data-pipeline-test
-      - run:
-          name: Run tests
-          command: docker-compose run resident-vulnerabilities-data-pipeline-test
   assume-role-development:
     executor: docker-python
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ workflows:
           filters:
             branches:
               only: development
-#
+
       - permit-staging-release:
           type: approval
           filters:
@@ -129,10 +129,9 @@ workflows:
           filters:
             branches:
               only: master
+
       - permit-production-release:
           type: approval
-          requires:
-            - deploy-to-staging
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,6 @@ commands:
           name: Install serverless CLI
           command: npm i -g serverless
       - run:
-          name: Build lambda
-          command: |
-            cd ./ResidentVulnerabilitiesDataPipeline/
-            chmod +x ./build.sh
-            ./build.sh
-      - run:
           name: Deploy lambda
           command: |
             cd ./ResidentVulnerabilitiesDataPipeline/


### PR DESCRIPTION
# What:
 - Merge `development` and `staging/production` workflows together into a single main workflow.
 - Make `development` workflow trigger from `master` branch rather than `development`.
 - Remove the built, test, and lint tests from the pipeline.
 - Remove unused build, test, lint configuration.
 - Decouple each environment's deployment.

# Why:
 - Doing this to avoid needing to create duplicate Pull Requests when going from `development` branch into the `master` branch.
 - Decoupling the environments to avoid needing to raise the 'remove x environment refs' PRs.
 - We don't need build, test, lint steps as these steps are used for QA when deploying new code. In our case we're looking to de-deploy (remove) the code and resources.

# Notes:
 - The pipeline is expected to fail still due to expired SSH key. This will get fixed soon enough.