### PR TITLE
Cap serverless to v3 to stay under the old license.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Deploy lambda
           command: |


### PR DESCRIPTION
# What:
 - Capped serverless framework used for deploying CloudFormation stacks to major version 3.

# Why:
 - The version 4 introduces licensing changes that requires paid license to use, which has neither been discussed, nor approved yet.

# Notes:
 - The pipeline will still fail after merge due to SSH key. Will address that once relevant.