### PR TITLE
Bump the Node.js version from 13 to 18.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI


### PR DESCRIPTION
# What:
 - Bump the pipeline's Node.js version from version 13 to 18.

# Why:
 - The version 13 is deprecated and doesn't work with the newer versions of serverless v3.
 - The higher, but <18 versions of Node.js have either an 80 second deprecation timer, or just a massive deprecation message obscuring the logs.

# Notes:
 - Again, the expired SSH key will get shortly addressed.