### PR TITLE
Retire `DevelopmentAPIs` environment's serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,12 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ResidentVulnerabilitiesDataPipeline/
-            sls deploy --stage <<parameters.stage>> --conceal
+            if [ "<<parameters.stage>>" = "development" ]
+            then
+              sls remove --stage <<parameters.stage>> --verbose
+            else
+              sls deploy --stage <<parameters.stage>> --conceal
+            fi
 
 jobs:
   assume-role-development:


### PR DESCRIPTION
# What:
 - Trigger the removal of `DevelopmentAPIs` serverless-managed resources.

# Why:
 - The application and the related resident-vulnerabilities API have been decommissioned on this environment.
