### PR TITLE
Forgot to make the `development` workflow trigger from `master` branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,20 +101,20 @@ workflows:
           type: approval
           filters:
             branches:
-              only: development
+              only: master
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
             - permit-development-release
           filters:
             branches:
-              only: development
+              only: master
       - deploy-to-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
 
       - permit-staging-release:
           type: approval


### PR DESCRIPTION
# What:
 - Make the `development` deployment workflow trigger from `master` branch instead of `development`.

# Why:
 - So that we could trigger the `DevelopmentAPIs` resource decommissioning. PR #15 

# Notes:
 - This changes was supposed to be a part of this PR #12 .