### PR TITLE
Retire `StagingAPIs` environment's serverless-managed resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ResidentVulnerabilitiesDataPipeline/
-            if [ "<<parameters.stage>>" = "development" ]
+            if [ "<<parameters.stage>>" = "staging" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,6 @@ commands:
             fi
 
 jobs:
-  assume-role-development:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_DEVELOPMENT
   assume-role-staging:
     executor: docker-python
     steps:
@@ -78,11 +73,6 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  deploy-to-development:
-    executor: docker-dotnet
-    steps:
-      - deploy-lambda:
-          stage: 'development'
   deploy-to-staging:
     executor: docker-dotnet
     steps:
@@ -97,25 +87,6 @@ jobs:
 workflows:
   deploy-staging-and-production:
     jobs:
-      - permit-development-release:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - assume-role-development:
-          context: api-assume-role-development-context
-          requires:
-            - permit-development-release
-          filters:
-            branches:
-              only: master
-      - deploy-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: master
-
       - permit-staging-release:
           type: approval
           filters:

--- a/ResidentVulnerabilitiesDataPipeline/serverless.yml
+++ b/ResidentVulnerabilitiesDataPipeline/serverless.yml
@@ -75,11 +75,6 @@ resources:
                         - "Ref": "ServerlessDeploymentBucket"
 custom:
   vpc:
-    development:
-      securityGroupIds:
-        - sg-0a457bf4e6eda31de
-      subnetIds:
-        - subnet-000b89c249f12a8ad
     staging:
       securityGroupIds:
         - sg-04fa13c6d25c5f5cc
@@ -93,6 +88,5 @@ custom:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
   bucketName:
-    development: drop-bucket-csv-to-postgres
     staging: qlik-bucket-csv-to-postgres-staging
     production: qlik-bucket-csv-to-postgres-production


### PR DESCRIPTION
# What:
 - Make the pipeline retire the serverless-managed resources on `StagingAPIs` environment.
 - Removed the no longer relevant `development` environment references within the configuration files.

# Why:
 - The application and the related API have been decommissioned on this environment.