### PR TITLE
Retire `ProductionAPIs` serverless-managed resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ResidentVulnerabilitiesDataPipeline/
-            if [ "<<parameters.stage>>" = "staging" ]
+            if [ "<<parameters.stage>>" = "production" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,16 +63,6 @@ commands:
             fi
 
 jobs:
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_STAGING
-  assume-role-production:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_PRODUCTION
   deploy-to-staging:
     executor: docker-dotnet
     steps:
@@ -85,27 +75,8 @@ jobs:
           stage: 'production'
 
 workflows:
-  deploy-staging-and-production:
+  deploy-production:
     jobs:
-      - permit-staging-release:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          requires:
-              - permit-staging-release
-          filters:
-             branches:
-               only: master
-      - deploy-to-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-
       - permit-production-release:
           type: approval
           filters:

--- a/ResidentVulnerabilitiesDataPipeline/serverless.yml
+++ b/ResidentVulnerabilitiesDataPipeline/serverless.yml
@@ -75,12 +75,6 @@ resources:
                         - "Ref": "ServerlessDeploymentBucket"
 custom:
   vpc:
-    staging:
-      securityGroupIds:
-        - sg-04fa13c6d25c5f5cc
-      subnetIds:
-        - subnet-06d3de1bd9181b0d7
-        - subnet-0ed7d7713d1127656
     production:
       securityGroupIds:
         - sg-0631be752dee5711a
@@ -88,5 +82,4 @@ custom:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
   bucketName:
-    staging: qlik-bucket-csv-to-postgres-staging
     production: qlik-bucket-csv-to-postgres-production


### PR DESCRIPTION
# What:
 - Trigger the removal of `ProductionAPIs` serverless-managed resources.

# Why:
 - The application and the related resident-vulnerabilities API have been decommissioned on this environment.

# Notes:
 - The only remaining related resource left that we're aware of is is the `qlik-bucket-csv-to-postgres-production` S3 bucket that we keep as its ownership is ambiguous.