### PR TITLE
Bring back missing `production` assume role job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,11 @@ commands:
             fi
 
 jobs:
-  deploy-to-staging:
-    executor: docker-dotnet
+  assume-role-production:
+    executor: docker-python
     steps:
-      - deploy-lambda:
-          stage: 'staging'
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRODUCTION
   deploy-to-production:
     executor: docker-dotnet
     steps:


### PR DESCRIPTION
# What:
 - Add back in missing `production` assume role job definition.

# Why:
 - It was removed by mistake.

# Notes:
 - This PR will trigger the infrastructure deployment changes of PR #18 .